### PR TITLE
Param svg painter

### DIFF
--- a/kicadsch/src/kicadSch_sigs.mli
+++ b/kicadsch/src/kicadSch_sigs.mli
@@ -17,7 +17,7 @@ type justify = J_left | J_right | J_center | J_bottom | J_top (** *)
 type style = Bold | Italic | BoldItalic | NoStyle (** *)
 (** Style of a text *)
 
-type kolor = NoColor | Black | Green | Red | Blue | Brown (** *)
+type kolor = [`NoColor | `Black | `Green | `Red | `Blue | `Brown ]
 (** Color of the text. These are the colors appearing in Kicad schematics *)
 
 type transfo = ((int * int) * (int * int))
@@ -57,7 +57,7 @@ module type Painter = sig
      filled at [corner], scaled at [scale] on [canvas]. @return the
      modified canvas *)
 
-  val paint_arc: ?kolor: kolor -> ?fill:kolor -> coord -> coord -> coord -> int -> t -> t
+  val paint_arc: ?kolor: kolor -> ?fill: kolor -> coord -> coord -> coord -> int -> t -> t
   (** [paint_arc ?kolor center start end radius canvas] paints an arc filled
      with [kolor] between [start] and [end] of [radius] around center on
      [canvas]. @return the modified canvas *)

--- a/kicadsch/src/kicadSch_sigs.mli
+++ b/kicadsch/src/kicadSch_sigs.mli
@@ -47,7 +47,7 @@ module type Painter = sig
      filled with the given [kolor] defined by [center] and [radius] on
      [canvas]. @return the modified canvas *)
 
-  val paint_rect: ?fill: kolor -> coord -> coord -> t -> t
+  val paint_rect: ?kolor: kolor -> ?fill: kolor -> coord -> coord -> t -> t
   (** [paint_rect ?kolor corner1 corner2 canvas] paints a rectangle
      filled with the given [kolor] defined by [corner1] and [corner2]
      on [canvas]. @return the modified canvas *)

--- a/kicadsch/src/kicadsch.ml
+++ b/kicadsch/src/kicadsch.ml
@@ -216,7 +216,7 @@ struct
       | J_right |J_bottom -> name ^ port_char
       | J_center -> name
 
-  let draw_port ?(kolor=Black) name ptype justif (Coord (x,y)) (Size l as s) canevas =
+  let draw_port ?(kolor=`Black) name ptype justif (Coord (x,y)) (Size l as s) canevas =
     let new_port_name = decorate_port_name name ptype justif in
     let orient = orientation_of_justify justif in
     let j = justif in
@@ -472,8 +472,8 @@ struct
     match l.labeltype with
     | TextLabel t -> begin
       let pcolor = match t with
-        | TextNote ->  Green
-        | WireLabel -> Red in
+        | TextNote ->  `Green
+        | WireLabel -> `Red in
       let Size s = l.size in
       let Coord (x,y) = l.c in
       let paint_line c' (line_index,l') =
@@ -483,8 +483,8 @@ struct
     end
     | PortLabel (prange, ptype) ->
        let pcolor = match prange with
-         | Glabel -> Green
-         | Hlabel -> Red in
+         | Glabel -> `Green
+         | Hlabel -> `Red in
        let new_type = (swap_type ptype) in
        draw_port ~kolor:pcolor line new_type l.orient l.c l.size c
 
@@ -588,7 +588,7 @@ struct
                      ~onerror:(fun () -> canevas)
                      ~process:(fun (Coord (x,y)) ->
                        let delta = 10 in
-                       P.paint_circle ~fill:Black (Coord (x,y)) delta canevas)
+                       P.paint_circle ~fill:`Black (Coord (x,y)) delta canevas)
     else if (String.compare line "$Sheet" = 0) then
       SheetContext None, canevas
     else if starts_with line "Text" then
@@ -663,9 +663,9 @@ struct
                             ~onerror: (fun () -> canevas)
                             ~process: (fun (c1, c2) ->
                               let kolor, width  = match l with
-                                | Bus | BusEntry -> Blue, Size 5
-                                | Wire | WireEntry -> Brown, Size 2
-                                | Line -> Black, Size 2
+                                | Bus | BusEntry -> `Blue, Size 5
+                                | Wire | WireEntry -> `Brown, Size 2
+                                | Line -> `Black, Size 2
                               in P.paint_line ~kolor ~width c1 c2 canevas))
     | SheetContext sc ->
        if (String.compare line "$EndSheet" = 0) then

--- a/plotkicadsch/src/listPainter.ml
+++ b/plotkicadsch/src/listPainter.ml
@@ -16,15 +16,15 @@ module L =  struct
     type t = listcanevas
     type painterContext = listcanevas
 
-    let paint_text ?(kolor=Black) text (o:orientation) coords s j stl ctx =
+    let paint_text ?(kolor=`Black) text (o:orientation) coords s j stl ctx =
       Text (kolor, text, o, coords, s, j, stl) :: ctx
-    let paint_line ?(kolor=Black) ?(width=(Size 2)) pt_start pt_end ctx =
+    let paint_line ?(kolor=`Black) ?(width=(Size 2)) pt_start pt_end ctx =
       Line (kolor, width, pt_start, pt_end) :: ctx
-    let paint_rect ?(fill=NoColor) pt dims ctx =
+    let paint_rect ?(fill=`NoColor) pt dims ctx =
       Rect (fill, pt, dims) :: ctx
-    let paint_circle ?(kolor=Black) ?(fill=NoColor) center radius ctx =
+    let paint_circle ?(kolor=`Black) ?(fill=`NoColor) center radius ctx =
       Circle (kolor, fill, center, radius):: ctx
-    let paint_arc ?(kolor=Black) ?(fill=NoColor) pt_center pt_start pt_stop radius  ctx =
+    let paint_arc ?(kolor=`Black) ?(fill=`NoColor) pt_center pt_start pt_stop radius  ctx =
       Arc (kolor, fill, pt_center, pt_start, pt_stop, radius) :: ctx
     let paint_image corner scale b c =
       Image (corner, scale, b) :: c

--- a/plotkicadsch/src/listPainter.ml
+++ b/plotkicadsch/src/listPainter.ml
@@ -4,7 +4,7 @@ type image_data = Buffer.t
 type t =
   | Text of kolor*string*orientation*coord*size*justify*style
   | Line of kolor*size*coord*coord
-  | Rect of kolor*coord*coord
+  | Rect of kolor*kolor*coord*coord
   | Circle of kolor*kolor*coord*int
   | Arc of kolor*kolor*coord*coord*coord*int
   | Image of coord*float*image_data
@@ -20,8 +20,8 @@ module L =  struct
       Text (kolor, text, o, coords, s, j, stl) :: ctx
     let paint_line ?(kolor=`Black) ?(width=(Size 2)) pt_start pt_end ctx =
       Line (kolor, width, pt_start, pt_end) :: ctx
-    let paint_rect ?(fill=`NoColor) pt dims ctx =
-      Rect (fill, pt, dims) :: ctx
+    let paint_rect ?(kolor=`Black) ?(fill=`NoColor) pt dims ctx =
+      Rect (kolor, fill, pt, dims) :: ctx
     let paint_circle ?(kolor=`Black) ?(fill=`NoColor) center radius ctx =
       Circle (kolor, fill, center, radius):: ctx
     let paint_arc ?(kolor=`Black) ?(fill=`NoColor) pt_center pt_start pt_stop radius  ctx =

--- a/plotkicadsch/src/plotgitsch.ml
+++ b/plotkicadsch/src/plotgitsch.ml
@@ -199,9 +199,9 @@ let internal_diff (d:string) (c: SvgPainter.diff_colors option) = (
       ListPainter.(
         let module O = SvgPainter in
         let kolor = match style with
-          | Theirs -> Kicadsch.Sigs.Red
-          | Ours -> Kicadsch.Sigs.Green
-          | Idem -> Kicadsch.Sigs.Black in
+          | Theirs -> `Old
+          | Ours -> `New
+          | Idem -> `ForeGround in
         match arg with
         | Text (_, text, o, c, s, j, style) -> O.paint_text ~kolor text o c s j style out_ctx
         | Line (_, s, from_, to_) -> O.paint_line ~kolor ~width:s from_ to_ out_ctx

--- a/plotkicadsch/src/plotgitsch.ml
+++ b/plotkicadsch/src/plotgitsch.ml
@@ -186,7 +186,7 @@ let internal_diff (d:string) (c: SvgPainter.diff_colors option) = (
         match arg with
         | Text (_, text, _o, Coord (x, y), Size s, _j, _style) -> Printf.sprintf "text %s %d %d %d" text x y s
         | Line (_, Size s, Coord (x1, y1), Coord (x2, y2)) -> Printf.sprintf "line %d %d -> %d %d %d" x1 y1 x2 y2 s
-        | Rect (_,  Coord (x1, y1), Coord (x2, y2)) -> Printf.sprintf "rectangle %d %d -> %d %d" x1 y1 x2 y2
+        | Rect (_, _,  Coord (x1, y1), Coord (x2, y2)) -> Printf.sprintf "rectangle %d %d -> %d %d" x1 y1 x2 y2
         | Circle (_, _, Coord (x, y), radius) -> Printf.sprintf "circle %d %d %d" x y radius
         | Arc (_, _ , Coord (x, y), Coord (x1, y1), Coord (x2, y2), radius) -> Printf.sprintf "arc %d %d -> %d %d %d %d %d" x1 y1 x2 y2 radius x y
         | Image (Coord (x, y), scale , _) -> Printf.sprintf "image %d %d %f" x y scale
@@ -205,7 +205,7 @@ let internal_diff (d:string) (c: SvgPainter.diff_colors option) = (
         match arg with
         | Text (_, text, o, c, s, j, style) -> O.paint_text ~kolor text o c s j style out_ctx
         | Line (_, s, from_, to_) -> O.paint_line ~kolor ~width:s from_ to_ out_ctx
-        | Rect (_,  c1, c2) -> O.paint_rect c1 c2 out_ctx
+        | Rect (_, _,  c1, c2) -> O.paint_rect ~kolor c1 c2 out_ctx
         | Circle (_, _, center, radius) -> O.paint_circle ~kolor center radius out_ctx
         | Arc (_, _ , center, start_, end_, radius) -> O.paint_arc ~kolor center start_ end_ radius out_ctx
         | Image (corner, scale , data) -> O.paint_image corner scale data out_ctx

--- a/plotkicadsch/src/svgPainter.ml
+++ b/plotkicadsch/src/svgPainter.ml
@@ -1,9 +1,11 @@
 open Tyxml.Svg
 open Kicadsch.Sigs
 
+type diff_colors = {old_ver: string; new_ver: string; fg: string; bg: string}
+
 type content = [ `Polyline | `Text | `Svg | `Rect | `Circle |`Path | `Image ]
 type dim = int*int
-type t =  { d: dim  ; c : content elt list} [@@inline]
+type t =  { d: dim  ; c : content elt list; colors: diff_colors option} [@@inline]
 
 let style_attr_of_style = function
   | Italic -> [a_font_style "italic"]
@@ -19,12 +21,17 @@ let anchor_attr_of_justify justif =
       | J_bottom -> `End
       | J_top -> `Start)
 
-let color_of_kolor k =
+let color_of_kolor k {colors; _} =
+  let green, red, black =
+    match colors with
+    | None ->  "#00FF00", "#FF0000", "#000000"
+    | Some { old_ver; new_ver; fg; _} -> new_ver, old_ver, fg
+  in
   let cstring = match k with
   | NoColor -> "none"
-  | Black -> "#000000"
-  | Red -> "#FF0000"
-  | Green -> "#00FF00"
+  | Black -> black
+  | Red -> red
+  | Green -> green
   | Blue -> "#0000CD"
   | Brown -> "#800000"
   in `Color (cstring, None)
@@ -43,7 +50,7 @@ let paint_text ?(kolor=Black) t (o:orientation) (Coord (x,y)) (Size size) justif
       | Orient_V -> (-90.) in
   let orient = (angle,None), Some(x_c,y_c)
   in
-  let color = color_of_kolor kolor in  { ctxt with c =
+  let color = color_of_kolor kolor ctxt in  { ctxt with c =
   (text ~a:([a_x_list [coord_of_int x] ; a_y_list [coord_of_int y] ; a_font_size size_in; j; a_transform[`Rotate orient]; a_fill color]@s) [pcdata t]) :: c}
 
 let paint_line ?(kolor=Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2)) ({c; _} as ctxt) =
@@ -53,19 +60,19 @@ let paint_line ?(kolor=Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2)
   let y2_in = float_of_int y2 in
   let Size width = width in
   let fwidth = (float_of_int width) *. 5. in { ctxt with c =
-  (polyline ~a:([a_points [(x1_in, y1_in); (x2_in, y2_in) ]; a_stroke_width (fwidth, Some `Px); a_stroke ( color_of_kolor kolor) ]) []) :: c}
+  (polyline ~a:([a_points [(x1_in, y1_in); (x2_in, y2_in) ]; a_stroke_width (fwidth, Some `Px); a_stroke ( color_of_kolor kolor ctxt) ]) []) :: c}
 
 let paint_rect ?(fill=NoColor) (Coord(x, y)) (Coord (dim_x, dim_y)) ({c;_ } as ctxt) = {ctxt with c =
-  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor Black)] []) :: c}
+  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill ctxt); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor Black ctxt)] []) :: c}
 
 let paint_circle ?(kolor=Black) ?(fill=NoColor) (Coord(x, y)) radius ({c; _ } as ctxt) ={ctxt with c =
-  (circle ~a:[a_r (coord_of_int radius); a_cx (coord_of_int x); a_cy (coord_of_int y); a_fill (color_of_kolor fill); a_stroke_width (10., Some `Px); a_stroke (color_of_kolor kolor) ] []) :: c}
+  (circle ~a:[a_r (coord_of_int radius); a_cx (coord_of_int x); a_cy (coord_of_int y); a_fill (color_of_kolor fill ctxt); a_stroke_width (10., Some `Px); a_stroke (color_of_kolor kolor ctxt) ] []) :: c}
 
 let paint_arc ?(kolor=Black) ?(fill=NoColor) (Coord (x, y)) (Coord(x1, y1)) (Coord (x2, y2)) radius ({c; _} as ctxt) =
   (* not sure how this thing behaves. This setup seems to work *)
   let sweepflag = if (x1-x)*(y2-y)>(x2-x)*(y1-y) then 1 else 0 in
   {ctxt with c =
-  ( path ~a:[a_d (Printf.sprintf "M%d,%d A%d,%d 0 0,%d %d,%d" x1 y1 radius radius sweepflag x2 y2); a_fill (color_of_kolor fill); a_stroke_width (10., Some`Px); a_stroke (color_of_kolor kolor)] []
+  ( path ~a:[a_d (Printf.sprintf "M%d,%d A%d,%d 0 0,%d %d,%d" x1 y1 radius radius sweepflag x2 y2); a_fill (color_of_kolor fill ctxt); a_stroke_width (10., Some`Px); a_stroke (color_of_kolor kolor ctxt)] []
   ) :: c}
 
 let get_png_dims b =
@@ -93,14 +100,18 @@ let paint_image (Coord (x, y)) scale b ({c; _} as ctxt) =
        a_xlink_href @@ "data:image/png;base64," ^ (B64.encode (Buffer.contents b))] [])
   :: c }
 
-let get_context () = {d=(0,0) ; c=[]}
+let get_context () = {d=(0,0) ; c=[]; colors=None}
+let get_color_context cols = {d=(0,0) ; c=[]; colors= cols}
 
 let set_canevas_size x y ctxt = {ctxt with d = (x,y)}
 
-let write ?(op=true) {d= (x,y); c}  =
+let write ?(op=true) {d= (x,y); c; colors}  =
   let fx = float x in
   let fy = float y in
   let o = (if op then  1.0 else 0.8) in
+  let bg = match colors with
+    | None -> "#FFFFFF"
+    | Some {bg; _} -> bg in
   let opacity = a_style @@ Printf.sprintf "stroke-opacity:%f;fill-opacity:%f;" o o  in
-  let svg_doc = svg  ~a:[a_width (fx *. 0.00254, Some `Cm); a_height (fy *. 0.00254, Some `Cm); a_viewBox (0.,0., float x, float y); a_font_family "Verdana, sans-serif";opacity] @@ (rect ~a:[a_fill (`Color ("#FFFFFF", None)); a_width (coord_of_int x); a_height (coord_of_int y)] [])::c in
+  let svg_doc = svg  ~a:[a_width (fx *. 0.00254, Some `Cm); a_height (fy *. 0.00254, Some `Cm); a_viewBox (0.,0., float x, float y); a_font_family "Verdana, sans-serif";opacity] @@ (rect ~a:[a_fill (`Color (bg, None)); a_width (coord_of_int x); a_height (coord_of_int y)] [])::c in
   Format.asprintf "%a" (Tyxml.Svg.pp ()) svg_doc

--- a/plotkicadsch/src/svgPainter.ml
+++ b/plotkicadsch/src/svgPainter.ml
@@ -22,24 +22,27 @@ let anchor_attr_of_justify justif =
       | J_top -> `Start)
 
 let color_of_kolor k {colors; _} =
-  let green, red, black =
+  let new_ver, old_ver, fg =
     match colors with
     | None ->  "#00FF00", "#FF0000", "#000000"
     | Some { old_ver; new_ver; fg; _} -> new_ver, old_ver, fg
   in
   let cstring = match k with
-  | NoColor -> "none"
-  | Black -> black
-  | Red -> red
-  | Green -> green
-  | Blue -> "#0000CD"
-  | Brown -> "#800000"
+  | `NoColor -> "none"
+  | `Black -> "#000000"
+  | `Red -> "#FF0000"
+  | `Green -> "#00FF00"
+  | `Blue -> "#0000CD"
+  | `Brown -> "#800000"
+  | `Old -> old_ver
+  | `New -> new_ver
+  | `ForeGround -> fg
   in `Color (cstring, None)
 
 (** SVG coord type conversion from int **)
 let coord_of_int x = float_of_int x, None
 
-let paint_text ?(kolor=Black) t (o:orientation) (Coord (x,y)) (Size size) justif styl ({c; _} as ctxt) =
+let paint_text ?(kolor=`Black) t (o:orientation) (Coord (x,y)) (Size size) justif styl ({c; _} as ctxt) =
   let size_in = Printf.sprintf "%f"  (float_of_int size) and
       j = anchor_attr_of_justify justif and
       s = style_attr_of_style styl and
@@ -53,7 +56,7 @@ let paint_text ?(kolor=Black) t (o:orientation) (Coord (x,y)) (Size size) justif
   let color = color_of_kolor kolor ctxt in  { ctxt with c =
   (text ~a:([a_x_list [coord_of_int x] ; a_y_list [coord_of_int y] ; a_font_size size_in; j; a_transform[`Rotate orient]; a_fill color]@s) [pcdata t]) :: c}
 
-let paint_line ?(kolor=Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2)) ({c; _} as ctxt) =
+let paint_line ?(kolor=`Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2)) ({c; _} as ctxt) =
   let x1_in = float_of_int x1 in
   let y1_in = float_of_int y1 in
   let x2_in = float_of_int x2 in
@@ -62,13 +65,13 @@ let paint_line ?(kolor=Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2)
   let fwidth = (float_of_int width) *. 5. in { ctxt with c =
   (polyline ~a:([a_points [(x1_in, y1_in); (x2_in, y2_in) ]; a_stroke_width (fwidth, Some `Px); a_stroke ( color_of_kolor kolor ctxt) ]) []) :: c}
 
-let paint_rect ?(fill=NoColor) (Coord(x, y)) (Coord (dim_x, dim_y)) ({c;_ } as ctxt) = {ctxt with c =
-  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill ctxt); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor Black ctxt)] []) :: c}
+let paint_rect ?(fill=`NoColor) (Coord(x, y)) (Coord (dim_x, dim_y)) ({c;_ } as ctxt) = {ctxt with c =
+  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill ctxt); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor `Black ctxt)] []) :: c}
 
-let paint_circle ?(kolor=Black) ?(fill=NoColor) (Coord(x, y)) radius ({c; _ } as ctxt) ={ctxt with c =
+let paint_circle ?(kolor=`Black) ?(fill=`NoColor) (Coord(x, y)) radius ({c; _ } as ctxt) ={ctxt with c =
   (circle ~a:[a_r (coord_of_int radius); a_cx (coord_of_int x); a_cy (coord_of_int y); a_fill (color_of_kolor fill ctxt); a_stroke_width (10., Some `Px); a_stroke (color_of_kolor kolor ctxt) ] []) :: c}
 
-let paint_arc ?(kolor=Black) ?(fill=NoColor) (Coord (x, y)) (Coord(x1, y1)) (Coord (x2, y2)) radius ({c; _} as ctxt) =
+let paint_arc ?(kolor=`Black) ?(fill=`NoColor) (Coord (x, y)) (Coord(x1, y1)) (Coord (x2, y2)) radius ({c; _} as ctxt) =
   (* not sure how this thing behaves. This setup seems to work *)
   let sweepflag = if (x1-x)*(y2-y)>(x2-x)*(y1-y) then 1 else 0 in
   {ctxt with c =

--- a/plotkicadsch/src/svgPainter.ml
+++ b/plotkicadsch/src/svgPainter.ml
@@ -65,8 +65,8 @@ let paint_line ?(kolor=`Black) ?(width=(Size 2)) (Coord (x1, y1)) (Coord (x2, y2
   let fwidth = (float_of_int width) *. 5. in { ctxt with c =
   (polyline ~a:([a_points [(x1_in, y1_in); (x2_in, y2_in) ]; a_stroke_width (fwidth, Some `Px); a_stroke ( color_of_kolor kolor ctxt) ]) []) :: c}
 
-let paint_rect ?(fill=`NoColor) (Coord(x, y)) (Coord (dim_x, dim_y)) ({c;_ } as ctxt) = {ctxt with c =
-  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill ctxt); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor `Black ctxt)] []) :: c}
+let paint_rect ?(kolor=`Black) ?(fill=`NoColor) (Coord(x, y)) (Coord (dim_x, dim_y)) ({c;_ } as ctxt) = {ctxt with c =
+  (rect ~a:[ a_x (coord_of_int x); a_y (coord_of_int y); a_width (coord_of_int dim_x); a_height (coord_of_int dim_y);a_fill (color_of_kolor fill ctxt); a_stroke_width (5., Some `Px); a_stroke (color_of_kolor kolor ctxt)] []) :: c}
 
 let paint_circle ?(kolor=`Black) ?(fill=`NoColor) (Coord(x, y)) radius ({c; _ } as ctxt) ={ctxt with c =
   (circle ~a:[a_r (coord_of_int radius); a_cx (coord_of_int x); a_cy (coord_of_int y); a_fill (color_of_kolor fill ctxt); a_stroke_width (10., Some `Px); a_stroke (color_of_kolor kolor ctxt) ] []) :: c}
@@ -116,5 +116,5 @@ let write ?(op=true) {d= (x,y); c; colors}  =
     | None -> "#FFFFFF"
     | Some {bg; _} -> bg in
   let opacity = a_style @@ Printf.sprintf "stroke-opacity:%f;fill-opacity:%f;" o o  in
-  let svg_doc = svg  ~a:[a_width (fx *. 0.00254, Some `Cm); a_height (fy *. 0.00254, Some `Cm); a_viewBox (0.,0., float x, float y); a_font_family "Verdana, sans-serif";opacity] @@ (rect ~a:[a_fill (`Color (bg, None)); a_width (coord_of_int x); a_height (coord_of_int y)] [])::c in
+  let svg_doc = svg  ~a:[a_width (fx *. 0.00254, Some `Cm); a_height (fy *. 0.00254, Some `Cm); a_viewBox (0.,0., float x, float y); a_font_family "Verdana, sans-serif";opacity] @@ (rect ~a:[a_fill (`Color (bg, None)); a_width (coord_of_int x); a_height (coord_of_int y) ; a_style  "stroke-opacity:1.0;fill-opacity:1.0;"] [])::c in
   Format.asprintf "%a" (Tyxml.Svg.pp ()) svg_doc


### PR DESCRIPTION
@leoheck

This should fix #10 . In fact, it wasn't as disruptive as anticipated, because my first analysis of the feature was wrong: the feature is not fully in the painter, but also partly in the differ object.

So in this branch you can test the feature with e.g.:
 ```console
 $  plotgitsch -ifirefox --colors=FF0000:0000FF:FFFFFF:000000
```

The colors field is the RGB values of old, new, foreground and background colors. 
To test, as usual, in `plotkicadsch` sources:

```
 $ git fetch  git@github.com:jnavila/plotkicadsch.git param_svgPainter
 $ git checkout FETCH_HEAD
 $ make build install
```

Let me know if it's ok.
